### PR TITLE
adding support to continue using pyopenssl after request version 2.24.0

### DIFF
--- a/esocial/client.py
+++ b/esocial/client.py
@@ -18,6 +18,7 @@ import requests
 import esocial
 
 from urllib3.util.ssl_ import create_urllib3_context
+from urllib3.contrib import pyopenssl
 from requests.adapters import HTTPAdapter
 
 from esocial import xml
@@ -39,6 +40,7 @@ class CustomHTTPSAdapter(HTTPAdapter):
         super(CustomHTTPSAdapter, self).__init__()
 
     def init_poolmanager(self, *args, **kwargs):
+        pyopenssl.inject_into_urllib3()
         context = create_urllib3_context()
         if self.ctx_options is not None:
             # Probably there is a better (pythonic) way to setting this up


### PR DESCRIPTION
this pull request broke the repository, https://github.com/psf/requests/pull/5443
as commented in the pull request if still wants to use pyOpenSSL is necessary to manually call `urllib3.contrib.pyopenssl.inject_into_urllib3()`